### PR TITLE
fix: render loop

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true,
-  experimental: {
-    appDir: false,
-  },
-};
+	//reactStrictMode: true,
+	experimental: {
+		appDir: false,
+	},
+}
 
-module.exports = nextConfig;
+module.exports = nextConfig

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,8 +3,6 @@ import { BsArrowDownShort, BsArrowLeftShort, BsArrowRightShort, BsArrowUpShort }
 import { usePagination, useSortBy, useTable } from 'react-table'
 import { ToggleSwitch, IToggleProps } from '@/components'
 import { useState } from 'react'
-import { Accordion } from '@/components'
-
 interface IProps {
 	data: any[]
 	columns: any[]


### PR DESCRIPTION
Render loop caused by enabled reactStrictMode in nextjs config. When enabled it renders components multiple times causing react to get in a loop from time to time.